### PR TITLE
🐛 fix forum name and Github username

### DIFF
--- a/germany/nurnberg/manuel-steinberg-1h4prsqu131ggsvp/community-member.txt
+++ b/germany/nurnberg/manuel-steinberg-1h4prsqu131ggsvp/community-member.txt
@@ -6,11 +6,11 @@ Organisation: kreativ-anders
 
 ----
 
-Forum: man
+Forum: manuel
 
 ----
 
-Github: kreativ-ander
+Github: kreativ-anders
 
 ----
 


### PR DESCRIPTION
Somehow some letters went off, so the links will not work properly. This PR will fix the typos.