### PR TITLE
New community map entry: Malte Müller

### DIFF
--- a/germany/hamburg/malte-muller-wmpetr787objb7ak/community-member.txt
+++ b/germany/hamburg/malte-muller-wmpetr787objb7ak/community-member.txt
@@ -1,0 +1,29 @@
+Name: Malte Müller
+
+----
+
+Organisation: WAF GMBH
+
+----
+
+Forum: 
+
+----
+
+Github: electricgecko
+
+----
+
+Discord: 
+
+----
+
+Instagram: electricgecko
+
+----
+
+Mastodon: @electricgecko@mastodon.social
+
+----
+
+Linkedin: 


### PR DESCRIPTION
### New profile

| Name | Malte Müller |
| :--- | :--- |
| Organisation | WAF GMBH |
| Mastodon | [@electricgecko@mastodon.social](https://mastodon.social/@electricgecko) |
| Github | [electricgecko](https://github.com/electricgecko) |
| Instagram | [electricgecko](https://instagram.com/electricgecko) |


#### Location

| Place | hamburg |
| :--- | :--- |
| Country | Germany |
| Latitude | 53.550341 |
| Longitude | 10.000654 |
| Map | [View](https://www.openstreetmap.org/?mlat=53.550341&mlon=10.000654) |
