### PR TITLE
New community map entry: Manuel von Rotz

### DIFF
--- a/switzerland/luzern/community-place.txt
+++ b/switzerland/luzern/community-place.txt
@@ -1,0 +1,9 @@
+Name: Luzern
+
+----
+
+Latitude: 47.052019
+
+----
+
+Longitude: 8.303831

--- a/switzerland/luzern/manuel-von-rotz-aehtrrvitrhtpfpl/community-member.txt
+++ b/switzerland/luzern/manuel-von-rotz-aehtrrvitrhtpfpl/community-member.txt
@@ -1,0 +1,29 @@
+Name: Manuel von Rotz
+
+----
+
+Organisation: MATOBE AG
+
+----
+
+Forum: 
+
+----
+
+Github: https://github.com/matobeag
+
+----
+
+Discord: 
+
+----
+
+Instagram: 
+
+----
+
+Mastodon: 
+
+----
+
+Linkedin: 

--- a/switzerland/luzern/manuel-von-rotz-aehtrrvitrhtpfpl/community-member.txt
+++ b/switzerland/luzern/manuel-von-rotz-aehtrrvitrhtpfpl/community-member.txt
@@ -2,7 +2,7 @@ Name: Manuel von Rotz
 
 ----
 
-Organisation: MATOBE AG
+Organisation: MATOBE Digital
 
 ----
 
@@ -10,7 +10,7 @@ Forum:
 
 ----
 
-Github: https://github.com/matobeag
+Github: matobeag
 
 ----
 


### PR DESCRIPTION
### New profile

| Name | Manuel von Rotz |
| :--- | :--- |
| Organisation | MATOBE AG |
| Github | [https://github.com/matobeag](https://github.com/https://github.com/matobeag) |


#### Location

| Place | Luzern |
| :--- | :--- |
| Country | Switzerland |
| Latitude | 47.052019 |
| Longitude | 8.303831 |
| Map | [View](https://www.openstreetmap.org/?mlat=47.052019&mlon=8.303831) |
