### PR TITLE
New community map entry: Tim de Gruisbourne

### DIFF
--- a/germany/berlin/tim-de-gruisbourne-igrcbbvowksyjdhc/community-member.txt
+++ b/germany/berlin/tim-de-gruisbourne-igrcbbvowksyjdhc/community-member.txt
@@ -1,0 +1,29 @@
+Name: Tim de Gruisbourne
+
+----
+
+Organisation: adlerschmidt GmbH
+
+----
+
+Forum: tideg
+
+----
+
+Github: tideg
+
+----
+
+Discord: tideg86
+
+----
+
+Instagram: tideg
+
+----
+
+Mastodon: 
+
+----
+
+Linkedin: tim-de-gruisbourne-171a4a236


### PR DESCRIPTION
### New profile

| Name | Tim de Gruisbourne |
| :--- | :--- |
| Organisation | adlerschmidt GmbH |
| Forum | [tideg](https://forum.getkirby.com/u/tideg) |
| Discord | [tideg86](https://chat.getkirby.com/) |
| Github | [tideg](https://github.com/tideg) |
| Linkedin | [tim-de-gruisbourne-171a4a236](https://linkedin.com/in/tim-de-gruisbourne-171a4a236) |
| Instagram | [tideg](https://instagram.com/tideg) |


#### Location

| Place | berlin |
| :--- | :--- |
| Country | Germany |
| Latitude | 52.5170365 |
| Longitude | 13.3888599 |
| Map | [View](https://www.openstreetmap.org/?mlat=52.5170365&mlon=13.3888599) |
