### PR TITLE
New community map entry: Arno Nühm

### DIFF
--- a/germany/wiesloch/arno-nuhm-t2m9nlmad4ue3mkm/community-member.txt
+++ b/germany/wiesloch/arno-nuhm-t2m9nlmad4ue3mkm/community-member.txt
@@ -1,0 +1,29 @@
+Name: Arno Nühm
+
+----
+
+Organisation: FEUERWASSER gmbh
+
+----
+
+Forum: 
+
+----
+
+Github: 
+
+----
+
+Discord: 
+
+----
+
+Instagram: 
+
+----
+
+Mastodon: @frwssr@mastodon.social
+
+----
+
+Linkedin: 

--- a/germany/wiesloch/community-place.txt
+++ b/germany/wiesloch/community-place.txt
@@ -1,0 +1,9 @@
+Name: Wiesloch
+
+----
+
+Latitude: 49.29515
+
+----
+
+Longitude: 8.700091


### PR DESCRIPTION
### New profile

| Name | Arno Nühm |
| :--- | :--- |
| Organisation | FEUERWASSER gmbh |
| Mastodon | [@frwssr@mastodon.social](https://mastodon.social/@frwssr) |


#### Location

| Place | Wiesloch |
| :--- | :--- |
| Country | Germany |
| Latitude | 49.29515 |
| Longitude | 8.700091 |
| Map | [View](https://www.openstreetmap.org/?mlat=49.29515&mlon=8.700091) |
