### PR TITLE
New community map entry: Mathieu Martin

### DIFF
--- a/france/montpellier/mathieu-martin-zuukcrlm7dtwlen2/community-member.txt
+++ b/france/montpellier/mathieu-martin-zuukcrlm7dtwlen2/community-member.txt
@@ -1,0 +1,29 @@
+Name: Mathieu Martin
+
+----
+
+Organisation: TROA
+
+----
+
+Forum: troa
+
+----
+
+Github: troadigital
+
+----
+
+Discord: 
+
+----
+
+Instagram: troa.digital
+
+----
+
+Mastodon: 
+
+----
+
+Linkedin: troa_digital


### PR DESCRIPTION
### New profile

| Name | Mathieu Martin |
| :--- | :--- |
| Organisation | TROA |
| Forum | [troa](https://forum.getkirby.com/u/troa) |
| Github | [troadigital](https://github.com/troadigital) |
| Linkedin | [troa_digital](https://linkedin.com/in/troa_digital) |
| Instagram | [troa.digital](https://instagram.com/troa.digital) |


#### Location

| Place | montpellier |
| :--- | :--- |
| Country | France |
| Latitude | 43.611242 |
| Longitude | 3.876734 |
| Map | [View](https://www.openstreetmap.org/?mlat=43.611242&mlon=3.876734) |
