### PR TITLE
New community map entry: Norbert Woehnl

### DIFF
--- a/japan/community-country.txt
+++ b/japan/community-country.txt
@@ -1,0 +1,1 @@
+Name: Japan

--- a/japan/tokyo/community-place.txt
+++ b/japan/tokyo/community-place.txt
@@ -1,0 +1,9 @@
+Name: Tokyo
+
+----
+
+Latitude: 35.68882
+
+----
+
+Longitude: 139.692526

--- a/japan/tokyo/norbert-woehnl-h1yb9iomw9wgm88r/community-member.txt
+++ b/japan/tokyo/norbert-woehnl-h1yb9iomw9wgm88r/community-member.txt
@@ -1,0 +1,29 @@
+Name: Norbert Woehnl
+
+----
+
+Organisation: 
+
+----
+
+Forum: 
+
+----
+
+Github: 
+
+----
+
+Discord: 
+
+----
+
+Instagram: 
+
+----
+
+Mastodon: @norbertwoehnl@famichiki.jp
+
+----
+
+Linkedin: 


### PR DESCRIPTION
### New profile

| Name | Norbert Woehnl |
| :--- | :--- |
| Mastodon | [@norbertwoehnl@famichiki.jp](https://famichiki.jp/@norbertwoehnl) |


#### Location

| Place | Tokyo |
| :--- | :--- |
| Country | Japan |
| Latitude | 35.68882 |
| Longitude | 139.692526 |
| Map | [View](https://www.openstreetmap.org/?mlat=35.68882&mlon=139.692526) |
